### PR TITLE
Adding aria label and pressed state

### DIFF
--- a/content/search-bar.php
+++ b/content/search-bar.php
@@ -5,7 +5,7 @@ if ( get_theme_mod( 'search_bar' ) != 'show' ) {
 ?>
 
 <div class='search-form-container'>
-	<button id="search-icon" class="search-icon">
+	<button id="search-icon" class="search-icon" aria-label="search" aria-pressed="false">
 		<i class="fas fa-search"></i>
 	</button>
 	<form role="search" method="get" class="search-form" action="<?php echo esc_url( home_url( '/' ) ); ?>">

--- a/js/functions.js
+++ b/js/functions.js
@@ -165,6 +165,11 @@ jQuery(document).ready(function($){
         // get the social icons
         var socialIcons = siteHeader.find('.social-media-icons');
 
+        // toggle aria-pressed state
+        // Ref: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/button_role#JavaScript_2
+        var pressed = $(this).attr("aria-pressed") === true;
+        $(this).attr("aria-pressed", !pressed);
+
         // if search bar already open
         if( $(this).hasClass('open') ) {
 


### PR DESCRIPTION
I am using Founder theme in one of the website. Lighthouse/Chrome DevTools audit threw accessibility error(missing label) with search button. This pull request fix the hilighted issue.
![founder-search-aria](https://user-images.githubusercontent.com/197331/68973654-d8ecff00-0814-11ea-9bdf-da189558607b.png)

BTW, thanks for the great minimalist theme.