### PR TITLE
Add display:swap with Google webfont requests

### DIFF
--- a/inc/scripts.php
+++ b/inc/scripts.php
@@ -5,6 +5,7 @@ function ct_founder_load_scripts_styles() {
 
 	$font_args = array(
 		'family' => urlencode( 'Noto Sans:400,700,400i' ),
+		'display' => 'swap',
 		'subset' => urlencode( 'latin,latin-ext' )
 	);
 	$fonts_url = add_query_arg( $font_args, '//fonts.googleapis.com/css' );


### PR DESCRIPTION
"Noto Sans" webfont is used in this theme. Observing flicker of all display text if we optimize & delay load Google webfont for performance. Recently Google Fonts started generating CSS file with 'font-display: swap' based on the query param. Changes to update the query param as needed.
![founder-webfont-warning](https://user-images.githubusercontent.com/197331/68975225-afce6d80-0818-11ea-9dcf-cfd9030ba4c5.png)

Ref: https://css-tricks.com/google-fonts-and-font-display/#article-header-id-0